### PR TITLE
A couple of suggested usability improvements

### DIFF
--- a/DuetLapse3.py
+++ b/DuetLapse3.py
@@ -736,9 +736,9 @@ def postProcess(cameraname, camera, vidparam, keeppics, novideo):
     else:
         logger.info('Job complete')
         if (win):
-            logger.info('Pictures can be found in directory '+basedir+'\\'+duetname+'\\frames'+timeJobStarted+')
+            logger.info('Pictures can be found in directory '+basedir+'\\'+duetname+'\\frames'+timeJobStarted)
         else:
-            logger.info('Pictures can be found in directory '+basedir+'/'+duetname+'/frames'+timeJobStarted+')
+            logger.info('Pictures can be found in directory '+basedir+'/'+duetname+'/frames'+timeJobStarted)
             
     
 #############################################################################

--- a/DuetLapse3.py
+++ b/DuetLapse3.py
@@ -734,7 +734,7 @@ def postProcess(cameraname, camera, vidparam, keeppics, novideo):
         logger.info('Video processing complete for '+cameraname)
         logger.info('Video is in file '+fn)
     else:
-        logger.info('Job complete)
+        logger.info('Job complete')
         if (win):
             logger.info('Pictures can be found in directory '+basedir+'\\'+duetname+'\\frames'+timeJobStarted+')
         else:

--- a/DuetLapse3.py
+++ b/DuetLapse3.py
@@ -205,9 +205,9 @@ def init():
    
     if ('file' in logtype or 'both' in logtype) :
         if (proccount > 1):
-             f_handler = logging.FileHandler(basedir+'/'+duetname+'/DuetLapse3.log', mode='a')
+             f_handler = logging.FileHandler(basedir+'/'+duetname+'/DuetLapse3-'+timeJobStarted+'.log', mode='a')
         else:
-             f_handler = logging.FileHandler(basedir+'/'+duetname+'/DuetLapse3.log', mode='w')        
+             f_handler = logging.FileHandler(basedir+'/'+duetname+'/DuetLapse3-'+timeJobStarted+'.log', mode='w')        
 
         f_format = logging.Formatter(duet+' - %(asctime)s - %(message)s')
         f_handler.setFormatter(f_format)

--- a/DuetLapse3.py
+++ b/DuetLapse3.py
@@ -249,9 +249,9 @@ def init():
     if (camparam2 != ''):
         logger.info("# Camera2 Override:")
         logger.info("# camparam2    =    {0:50s}".format(camparam2))   
-    logger.info("# deletepics   =     {0:50s}".format(deletepics))
+    logger.info("# deletepics   =     {0:50s}".format(str(deletepics)))
     logger.info("# Video Settings:")
-    logger.info("# novideo   =     {0:50s}".format(novideo))
+    logger.info("# novideo   =     {0:50s}".format(str(novideo)))
     logger.info("# extratime   =     {0:50s}".format(extratime))
     if (vidparam1 != ''):
         logger.info("# Video1 Override:")
@@ -691,7 +691,7 @@ def oneInterval(cameraname, camera, weburl, camparam):
         onePhoto(cameraname, camera, weburl, camparam)
     
 def postProcess(cameraname, camera, vidparam, keeppics, novideo):
-    if (novideo != true):
+    if (novideo != 'novideo'):
         logger.info('')
         if (cameraname == 'Camera1'):
             frame = frame1
@@ -726,7 +726,7 @@ def postProcess(cameraname, camera, vidparam, keeppics, novideo):
             cmd = eval(vidparam)    
               
         subprocess.call(cmd, shell=True)
-        if (deletepics):
+        if (deletepics == 'deletepics'):
             if (win):
                 subprocess.call('rmdir "'+basedir+'\\'+duetname+'\\frames'+timeJobStarted+'" /s /q'+debug, shell=True)
             else:

--- a/DuetLapse3.py
+++ b/DuetLapse3.py
@@ -121,7 +121,7 @@ def init():
     movehead = args['movehead']  
     standby = args['standby']
     #Camera
-    global camera1, camera2, weburl1, weburl2, keeppics     
+    global camera1, camera2, weburl1, weburl2, deletepics     
     camera1   = args['camera1'][0]
     camera2   = args['camera2'][0]
     weburl1   = args['weburl1'][0]
@@ -133,6 +133,7 @@ def init():
     global extratime, novideo   
     extratime = str(args['extratime'] [0])
     novideo = args['novideo']
+    if (novideo == 'novideo'): deletepics = ''
     
     #Overrides
     global camparam1, camparam2, vidparam1, vidparam2
@@ -691,7 +692,7 @@ def oneInterval(cameraname, camera, weburl, camparam):
         onePhoto(cameraname, camera, weburl, camparam)
     
 def postProcess(cameraname, camera, vidparam):
-    if (novideo != 'novideo'):
+    if (novideo == ''):
         logger.info('')
         if (cameraname == 'Camera1'):
             frame = frame1

--- a/DuetLapse3.py
+++ b/DuetLapse3.py
@@ -690,7 +690,7 @@ def oneInterval(cameraname, camera, weburl, camparam):
         logger.info(cameraname+': capturing frame '+str(frame)+' at layer '+str(zn)+' after '+str(seconds)+' seconds')
         onePhoto(cameraname, camera, weburl, camparam)
     
-def postProcess(cameraname, camera, vidparam, keeppics, novideo):
+def postProcess(cameraname, camera, vidparam):
     if (novideo != 'novideo'):
         logger.info('')
         if (cameraname == 'Camera1'):

--- a/DuetLapse3.py
+++ b/DuetLapse3.py
@@ -47,7 +47,7 @@ def setStartValues():
     #initialize timers
     timePriorPhoto1 = time.time()
     timePriorPhoto2 = time.time()
-    timeJobStarted = time.strftime("%Y%m%d-%H%M%S")
+    timeJobStarted = time.strftime("%y%m%d-%H%M%S")
     
     #reset the frame counters
     frame1 = 0       
@@ -484,7 +484,7 @@ def cleanupFiles():
     #Make sure there is a directory for the resulting video
     global win
     global timeJobStarted
-    timeJobStarted = time.strftime("%Y%m%d-%H%M%S")
+    timeJobStarted = time.strftime("%y%m%d-%H%M%S")
     if (win):
         subprocess.call('mkdir "'+basedir+'\\'+duetname+'"'+debug, shell=True)
         #Create the tmp directory

--- a/DuetLapse3.py
+++ b/DuetLapse3.py
@@ -692,7 +692,7 @@ def oneInterval(cameraname, camera, weburl, camparam):
         onePhoto(cameraname, camera, weburl, camparam)
     
 def postProcess(cameraname, camera, vidparam):
-    if (novideo == ''):
+    if (novideo != 'novideo'):
         logger.info('')
         if (cameraname == 'Camera1'):
             frame = frame1

--- a/DuetLapse3.py
+++ b/DuetLapse3.py
@@ -327,8 +327,8 @@ def init():
         
     if (novideo and deletepics):
         logger.info('************************************************************************************')
-        logger.info('* Note "-deletepics ignored since having -novideo and -deletepics together would
-        logger.info('* result in nothing being generated
+        logger.info('* Note "-deletepics ignored since having -novideo and -deletepics together would')
+        logger.info('* result in nothing being generated.')
         logger.info('************************************************************************************')
 
     #Invalid combinations

--- a/DuetLapse3.py
+++ b/DuetLapse3.py
@@ -133,7 +133,7 @@ def init():
     global extratime, novideo   
     extratime = str(args['extratime'] [0])
     novideo = args['novideo']
-    if (novideo == 'novideo'): deletepics = ''
+    if (novideo == True): deletepics = False
     
     #Overrides
     global camparam1, camparam2, vidparam1, vidparam2

--- a/DuetLapse3.py
+++ b/DuetLapse3.py
@@ -133,7 +133,6 @@ def init():
     global extratime, novideo   
     extratime = str(args['extratime'] [0])
     novideo = args['novideo']
-    if (novideo == True): deletepics = False
     
     #Overrides
     global camparam1, camparam2, vidparam1, vidparam2
@@ -326,12 +325,6 @@ def init():
         logger.info('************************************************************************************')
 
         
-    if (novideo and deletepics):
-        logger.info('************************************************************************************')
-        logger.info('* Note "-deletepics ignored since having -novideo and -deletepics together would')
-        logger.info('* result in nothing being generated.')
-        logger.info('************************************************************************************')
-
     #Invalid combinations
     
     logger.info('')
@@ -379,7 +372,13 @@ def init():
         logger.info('contain its own pauses.  These cannot be used together.')
         logger.info('************************************************************************************')
         sys.exit(2)
-        
+
+    if (novideo and deletepics):
+        logger.info('************************************************************************************')
+        logger.info('* Invalid Combination: "-deletepics and -novideo together would result in nothing being generated.')
+        logger.info('************************************************************************************')
+        sys.exit(2)
+
 
     def checkDependencies(camera):        
         #

--- a/DuetLapse3.py
+++ b/DuetLapse3.py
@@ -692,7 +692,7 @@ def oneInterval(cameraname, camera, weburl, camparam):
         onePhoto(cameraname, camera, weburl, camparam)
     
 def postProcess(cameraname, camera, vidparam):
-    if (novideo != 'novideo'):
+    if (novideo != True):
         logger.info('')
         if (cameraname == 'Camera1'):
             frame = frame1
@@ -727,11 +727,12 @@ def postProcess(cameraname, camera, vidparam):
             cmd = eval(vidparam)    
               
         subprocess.call(cmd, shell=True)
-        if (deletepics == 'deletepics'):
+        if (deletepics == True):
             if (win):
-                subprocess.call('rmdir "'+basedir+'\\'+duetname+'\\frames'+timeJobStarted+'" /s /q'+debug, shell=True)
+                subprocess.call('rmdir "'+basedir+'\\'+duetname+'\\frames-'+timeJobStarted+'" /s /q'+debug, shell=True)
             else:
-                subprocess.call('rm -rf "'+basedir+'/'+duetname+'/frames'+timeJobStarted+'"'+debug, shell=True)
+                subprocess.call('rm -rf "'+basedir+'/'+duetname+'/frames-'+timeJobStarted+'"'+debug, shell=True)
+            logger.info('Captured photos deleted')
         logger.info('Video processing complete for '+cameraname)
         logger.info('Video is in file '+fn)
     else:

--- a/DuetLapse3.py
+++ b/DuetLapse3.py
@@ -126,7 +126,7 @@ def init():
     camera2   = args['camera2'][0]
     weburl1   = args['weburl1'][0]
     weburl2   = args['weburl2'][0]
-    deletepics  = args['keeppics']
+    deletepics  = args['deletepics']
 
 
     #Video

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ In most cases the default will be suitable.
 **example**
 
 -instances single   #There can only be one instance of DuetLapse3.py running<br>
--instance oneip     #For each printer (set by -duet), there can only be one instance of DuetLapse3.py running<br>
+-instances oneip    #For each printer (set by -duet), there can only be one instance of DuetLapse3.py running<br>
 -instances many     #No restriction on the number of instances<br>
 </pre>
 
@@ -223,7 +223,7 @@ It is useful for having DuetLapse running but not actually doing anything until 
 <pre>
 **example**
 
--stopcmd #Causes internal http listener to start and listen on port 8082<br>
+-standby   #Causes internal http listener to start and listen on port 8082<br>
 </pre>
 
 #### -dontwait
@@ -321,8 +321,8 @@ If omitted it has no value. url specifies the location to capture images for cam
 #### -camera2 [usb||pi||web||stream||other]
 If omitted has no default (unlike camera1). Has the same parameters as -camera1
 
-#### -webur2 [url]
-Has the same parameters as -weburl2
+#### -weburl2 [url]
+Has the same parameters as -weburl1
 
 #### -camparam1="[command]"
 If omitted has no default. Used in conjunction with -camera1 to define how the images will be captured.<br>


### PR DESCRIPTION
added the option -deletepics so that captured photos are automatically deleted once the video has been successfully generated, acts as rudimentary housekeeping to prevent these files from filling up the target device due to another change outlined below

added the option -novideo so that no video gets generated at the end of the job, for those who want to retain just the captured photos and generate their own timelapse from them (cannot be used in conjunction with -deletepics)

re-worked the directories so that the photos get stored in a unique directory for each job, to prevent subsequent jobs from deleting the captured images from previous jobs. The directory gets named based on printer ip/name+datetime. The only way this is an issue is if the same printer starts multiple jobs within the same second